### PR TITLE
Remove `jQuery podcast`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Here is also [CSS preprocessors curated list](https://github.com/showcases/css-p
 * [The Big Web Show](http://5by5.tv/bigwebshow/) - topics like web publishing, art direction, content strategy, typography, web technology, and more. It's everything web that matters.
 * [The Web Ahead](http://5by5.tv/webahead/) - Conversations with world experts on changing technologies and future of the web.
 * [Non Breaking Space Show](http://goodstuff.fm/nbsp) - Seeking out the best, brightest, and smartest creative people on digital art, design, and development.
-* [jQuery Podcast](http://podcast.jquery.com/) - If you’re familiar with jQuery (and you probably are), you know there’s a podcast to go with it.
 * [The Changelog](https://changelog.com/) - The tagline for the Changelog says it all: “Open Source moves fast. Keep up.” This podcast, and the accompanying blog, is all about keeping you updated with the latest in Open Source Technology.
 
 ## Twitter


### PR DESCRIPTION
The jQuery podcast has been dead for years now so it's getting time to remove it :wink: Outdated content can't be a good idea for anyone.