### PR TITLE
Add krmp.cc color stylsheet generator tool to misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Here is [CSS in JS techniques comparison](https://github.com/MicheleBertoli/css-
 
 * [Single Div Project](https://github.com/ManrajGrover/SingleDivProject) - One `<div>`. Many possibilities.
 * [Can I use](http://caniuse.com/) - Browser support for CSS, HTML5 and other front-end web technologies.
+* [krmp.cc](https://github.com/dadleyy/krmp.cc) - On-the-fly css stylesheet generator for `background-color` & `color` rules.
 
 <sub>[⇧ back to top](#contents)</sub>
 


### PR DESCRIPTION
I created this little golang project that spits out css class rules that manipulate the `background-color` and `color` properties of elements they are applied to. the stylesheet is generated on the fly based on url params:

* [`/6e6/preview`](https://krmp.cc/6e6/preview)
* [`/ae448e/preview?steps=10`](https://krmp.cc/ae448e/preview?steps=10)
* [`/55a2ef/preview?steps=6&noconflict=hi`](https://krmp.cc/55a2ef/preview?steps=6&noconflict=hi)

etc...