### PR TITLE
Add newer edition of book "CSS: The Missing Manual"

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 ## Books :books:
 
 * [CSS Secrets](http://shop.oreilly.com/product/0636920031123.do) – Better Solutions to Everyday Web Design Problems
-* [CSS3: The Missing Manual ](http://shop.oreilly.com/product/0636920024996.do) – Really Helpful in Advancing your Design Skills to a whole new Level
+* [CSS: The Missing Manual](http://shop.oreilly.com/product/0636920036357.do) – Really Helpful in Advancing your Design Skills to a whole new Level
 
 <sub>[⇧ back to top](#contents)</sub>
 


### PR DESCRIPTION
This book has a newer edition from 2015 (instead of 2012 in the older edition). 